### PR TITLE
Fix KeyError bug

### DIFF
--- a/revolt/websocket.py
+++ b/revolt/websocket.py
@@ -126,6 +126,7 @@ class WebsocketHandler:
         message = self.state.get_message(payload["id"])
 
         data = payload["data"]
+        data["content"] = data.get("content", None)
         kwargs = {}
 
         if data["content"]:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\site-packages\revolt\websocket.py", line 92, in handle_event
    await func(payload)
  File "C:\Program Files\Python310\lib\site-packages\revolt\websocket.py", line 131, in handle_messageupdate
    if data["content"]:
KeyError: 'content'
``` 
fix
**raises when message doesn't have content**