### PR TITLE
fix await error

### DIFF
--- a/examples/commands.py
+++ b/examples/commands.py
@@ -1,12 +1,11 @@
 import asyncio
-
 import aiohttp
 
 import revolt
 from revolt.ext import commands
 
 
-class Client(commands.CommandsClient):
+class Bot(commands.CommandsClient):
     async def get_prefix(self, message: revolt.Message):
         return "!"
 
@@ -16,7 +15,7 @@ class Client(commands.CommandsClient):
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        client = Client(session, "BOT TOKEN HERE")
-        await client.start()
+        bot = Bot(session, "BOT TOKEN HERE")
+        await bot.start()
 
 asyncio.run(main())

--- a/revolt/channel.py
+++ b/revolt/channel.py
@@ -181,7 +181,7 @@ class TextChannel(Channel, Messageable, EditableChannel):
         else:
             self.icon = None
 
-    def _get_channel_id(self) -> str:
+    async def _get_channel_id(self) -> str:
         return self.id
 
     @property

--- a/revolt/client.py
+++ b/revolt/client.py
@@ -45,7 +45,7 @@ class Client:
         The max amount of messages stored in the cache, by default this is 5k
     """
     
-    def __init__(self, session: aiohttp.ClientSession, token: str, api_url: str = "https://api.revolt.chat", max_messages: int = 5000):
+    def __init__(self, session: aiohttp.ClientSession, token: str, *, api_url: str = "https://api.revolt.chat", max_messages: int = 5000):
         self.session = session
         self.token = token
         self.api_url = api_url


### PR DESCRIPTION
```
Task exception was never retrieved
future: <Task finished name='Task-19' coro=<Client.on_message() done, defined at /home/Caeden/Github/revolt.py/__main__.py:6> exception=TypeError("object str can't be used in 'await' expression")>
Traceback (most recent call last):
  File "/home/Caeden/Github/revolt.py/__main__.py", line 8, in on_message
    await message.channel.send("hi how are you")
  File "/home/Caeden/Github/revolt.py/revolt/messageable.py", line 62, in send
    message = await self.state.http.send_message(await self._get_channel_id(), content, embed_payload, attachments, reply_payload, masquerade_payload)
TypeError: object str can't be used in 'await' expression
```
`_get_channel_id` was not an asynchronous function

- make api_url and max_messages a kwarg