### PR TITLE
Implement mention for users, members and channels

### DIFF
--- a/revolt/channel.py
+++ b/revolt/channel.py
@@ -79,6 +79,12 @@ class Channel:
 
         return self.state.get_server(self.server_id)
 
+    @property
+    def mention(self) -> str:
+        """:class:`str`: Returns a string that allows you to mention the given channel."""
+        return f"<#{self.id}>"
+
+
 class SavedMessageChannel(Channel, Messageable):
     """The Saved Message Channel"""
     def __init__(self, data: SavedMessagesPayload, state: State):

--- a/revolt/member.py
+++ b/revolt/member.py
@@ -55,6 +55,11 @@ class Member(User):
         """Optional[:class:`Asset`] The avatar the member is displaying, this includes guild avatars and masqueraded avatar"""
         return self.masquerade_avatar or self.guild_avatar or self.original_avatar
 
+    @property
+    def mention(self) -> str:
+        """:class:`str`: Returns a string that allows you to mention the given member."""
+        return f"<@{self.id}>"
+
     def _update(self, *, nickname: Optional[str] = None, avatar: Optional[File] = None, roles: Optional[list[str]] = None):
         if nickname:
             self.nickname = nickname

--- a/revolt/user.py
+++ b/revolt/user.py
@@ -131,6 +131,11 @@ class User(Messageable):
         """Optional[:class:`Asset`] The avatar the member is displaying, this includes there orginal avatar and masqueraded avatar"""
         return self.masquerade_avatar or self.original_avatar
 
+    @property
+    def mention(self) -> str:
+        """:class:`str`: Returns a string that allows you to mention the given user."""
+        return f"<@{self.id}>"
+
     def _update(self, *, status: Optional[StatusPayload] = None, profile_content: Optional[str] = None, profile_background: Optional[File] = None, avatar: Optional[File] = None, online: Optional[bool] = None):
         if status:
             presence = status.get("presence")


### PR DESCRIPTION
Added a `mention` property to the revolt.Member, revolt.User and revolt.Channel classes

Example: 
```py
@property
def mention(self) -> str:
    """:class:`str`: Returns a string that allows you to mention the given user."""
    return f"<@{self.id}>
```