### PR TITLE
Fix typo in the docstring of `FeatureDisabled`

### DIFF
--- a/revolt/errors.py
+++ b/revolt/errors.py
@@ -16,7 +16,7 @@ class ServerError(RevoltError):
     "Internal server error"
 
 class FeatureDisabled(RevoltError):
-    """Base class for any any feature disabled"""
+    """Base class for any feature disabled errors"""
 
 class AutumnDisabled(FeatureDisabled):
     """The autumn feature is disabled"""


### PR DESCRIPTION
A typo occurred in [`errors.py`](https://github.com/revoltchat/revolt.py/blob/master/revolt/errors.py) file where `any` was repeated twice, this PR fixes a grammatical error in the docstring.