### PR TITLE
fix Message._update

### DIFF
--- a/revolt/message.py
+++ b/revolt/message.py
@@ -115,14 +115,15 @@ class Message(Ulid):
         else:
             self.interactions = None
 
-    def _update(self, *, content: Optional[str] = None, embeds: Optional[list[EmbedPayload]] = None, edited: int):
+    def _update(self, *, content: Optional[str] = None, embeds: Optional[list[EmbedPayload]] = None, edited: Optional[str] = None):
         if content is not None:
             self.content = content
 
-        self.edited = datetime.datetime.fromtimestamp(edited / 1000)
-
         if embeds is not None:
             self.embeds = [to_embed(embed, self.state) for embed in embeds]
+
+        if edited is not None:
+            self.edited_at = datetime.datetime.strptime(edited, "%Y-%m-%dT%H:%M:%S.%f%z")
 
     async def edit(self, *, content: Optional[str] = None, embeds: Optional[list[SendableEmbed]] = None) -> None:
         """Edits the message. The bot can only edit its own message

--- a/revolt/message.py
+++ b/revolt/message.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from .asset import Asset, PartialAsset
 from .channel import Messageable
@@ -115,7 +115,7 @@ class Message(Ulid):
         else:
             self.interactions = None
 
-    def _update(self, *, content: Optional[str] = None, embeds: Optional[list[EmbedPayload]] = None, edited: Optional[str] = None):
+    def _update(self, *, content: Optional[str] = None, embeds: Optional[list[EmbedPayload]] = None, edited: Optional[Union[str, int]] = None):
         if content is not None:
             self.content = content
 
@@ -123,7 +123,10 @@ class Message(Ulid):
             self.embeds = [to_embed(embed, self.state) for embed in embeds]
 
         if edited is not None:
-            self.edited_at = datetime.datetime.strptime(edited, "%Y-%m-%dT%H:%M:%S.%f%z")
+            if isinstance(edited, int):
+                self.edited_at = datetime.datetime.fromtimestamp(edited / 1000, tz=datetime.timezone.utc)
+            else:
+                self.edited_at = datetime.datetime.strptime(edited, "%Y-%m-%dT%H:%M:%S.%f%z")
 
     async def edit(self, *, content: Optional[str] = None, embeds: Optional[list[SendableEmbed]] = None) -> None:
         """Edits the message. The bot can only edit its own message

--- a/revolt/types/gateway.py
+++ b/revolt/types/gateway.py
@@ -11,6 +11,7 @@ from .permissions import Overwrite
 
 if TYPE_CHECKING:
     from .category import Category
+    from .embed import Embed
     from .emoji import Emoji
     from .file import File
     from .member import Member, MemberID
@@ -65,7 +66,8 @@ class MessageEventPayload(BasePayload, Message):
 
 class MessageUpdateData(TypedDict):
     content: str
-    edited: int
+    embeds: list[Embed]
+    edited: str
 
 class MessageUpdateEventPayload(BasePayload):
     channel: str

--- a/revolt/types/gateway.py
+++ b/revolt/types/gateway.py
@@ -67,7 +67,7 @@ class MessageEventPayload(BasePayload, Message):
 class MessageUpdateData(TypedDict):
     content: str
     embeds: list[Embed]
-    edited: str
+    edited: Union[str, int]
 
 class MessageUpdateEventPayload(BasePayload):
     channel: str


### PR DESCRIPTION
Edited field on MessageUpdate events is a string in iso8601 format not a timestamp.
Also when using the /global command a MessageUpdate event without a edited field is received

## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
