### PR TITLE
Provide `dotenv` examples

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}
-      - run: pip install .[speedups,docs]
+      - run: pip install .[speedups,docs,python-dotenv]
       - uses: jakebailey/pyright-action@v1
         with:
           python-version: ${{ matrix.version }}
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}
-      - run: pip install .[speedups,docs]
+      - run: pip install .[speedups,docs,python-dotenv]
       - uses: jakebailey/pyright-action@v1
         with:
           python-version: ${{ matrix.version }}

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}
-      - run: pip install .[speedups,docs,python-dotenv]
+      - run: pip install .[speedups,docs] python-dotenv
       - uses: jakebailey/pyright-action@v1
         with:
           python-version: ${{ matrix.version }}
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}
-      - run: pip install .[speedups,docs,python-dotenv]
+      - run: pip install .[speedups,docs] python-dotenv
       - uses: jakebailey/pyright-action@v1
         with:
           python-version: ${{ matrix.version }}

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -10,6 +10,7 @@ class Client(revolt.Client):
 
 async def main():
     async with aiohttp.ClientSession() as session:
+        # Storing the token in source code like this is bad practice. Please see the "dotenv" example for a more secure way of storing bot tokens.
         client = Client(session, "BOT TOKEN HERE")
         await client.start()
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -10,7 +10,8 @@ class Client(revolt.Client):
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        # Storing the token in source code like this is bad practice. Please see the "dotenv" example for a more secure way of storing bot tokens.
+        # Storing the token in source code like this is bad practice.
+        # Please see the "dotenv" example for a more secure way of storing bot tokens.
         client = Client(session, "BOT TOKEN HERE")
         await client.start()
 

--- a/examples/commands.py
+++ b/examples/commands.py
@@ -16,6 +16,8 @@ class Client(commands.CommandsClient):
 
 async def main():
     async with aiohttp.ClientSession() as session:
+        # Storing the token in source code like this is bad practice.
+        # Please see the "dotenv" example for a more secure way of storing bot tokens.
         client = Client(session, "BOT TOKEN HERE")
         await client.start()
 

--- a/examples/dotenv.py
+++ b/examples/dotenv.py
@@ -1,3 +1,5 @@
+# Before using this example, make sure you install dotenv with the following command:
+# pip install python-dotenv
 import asyncio
 import os
 from dotenv import load_dotenv

--- a/examples/dotenv.py
+++ b/examples/dotenv.py
@@ -19,9 +19,9 @@ class Client(revolt.Client):
 async def main():
     # The comment on line 24 exists to suppress a Pyright error on the GitHub repository
     # due to the '.env' file not existing and therefore the token not being accessible.
-    # You can remove these comments if you're using this example as intended.
+    # You should remove these comments if you're using this example as intended.
     async with aiohttp.ClientSession() as session:
-        client = Client(session, token) # reportGeneralTypeIssues: ignore 
+        client = Client(session, token) # type: ignore 
         await client.start()
 
 asyncio.run(main())

--- a/examples/dotenv.py
+++ b/examples/dotenv.py
@@ -1,0 +1,24 @@
+import asyncio
+import os
+from dotenv import load_dotenv
+import aiohttp
+import revolt
+
+load_dotenv()
+token = os.getenv('TOKEN')
+
+# Create a file in your bot's core directory called ".env".
+# Add the following line to the .env file you just created:
+# TOKEN=TOKEN_GOES_HERE
+
+class Client(revolt.Client):
+    async def on_message(self, message: revolt.Message):
+        if message.content == "hello":
+            await message.channel.send("hi how are you")
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        client = Client(session, token)
+        await client.start()
+
+asyncio.run(main())

--- a/examples/dotenv.py
+++ b/examples/dotenv.py
@@ -18,7 +18,7 @@ class Client(revolt.Client):
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        client = Client(session, token)
+        client = Client(session, token) # pylint: disable=reportGeneralTypeIssues
         await client.start()
 
 asyncio.run(main())

--- a/examples/dotenv.py
+++ b/examples/dotenv.py
@@ -17,8 +17,12 @@ class Client(revolt.Client):
             await message.channel.send("hi how are you")
 
 async def main():
+    # The comment below exists to suppress a Pylint error on the GitHub repository
+    # due to the '.env' file not existing and therefore the token not being accessible.
+    # You can remove these comments if you're using this example as intended.
+    # pylint: disable=reportGeneralTypeIssues
     async with aiohttp.ClientSession() as session:
-        client = Client(session, token) # pylint: disable=reportGeneralTypeIssues
+        client = Client(session, token)
         await client.start()
 
 asyncio.run(main())

--- a/examples/dotenv.py
+++ b/examples/dotenv.py
@@ -17,12 +17,11 @@ class Client(revolt.Client):
             await message.channel.send("hi how are you")
 
 async def main():
-    # The comment below exists to suppress a Pylint error on the GitHub repository
+    # The comment on line 24 exists to suppress a Pyright error on the GitHub repository
     # due to the '.env' file not existing and therefore the token not being accessible.
     # You can remove these comments if you're using this example as intended.
-    # pylint: disable=reportGeneralTypeIssues
     async with aiohttp.ClientSession() as session:
-        client = Client(session, token)
+        client = Client(session, token) # reportGeneralTypeIssues: ignore 
         await client.start()
 
 asyncio.run(main())


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [✅] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [✅] I have tested my changes locally and they are working as intended
* [✅ ] These changes do not have any notable side effects on other Revolt projects

From me on the [Revolt.py server](https://app.revolt.chat/server/01FDD3BH2G3D5S37A6RRBANQNX/channel/01FDD3BH2GFGVSNWTZHTZ26G46/01H37PP6D4FPG3YKNXJBM05EKP):

> so, I've been looking at the examples for revolt.py bots - going off my discord knowledge, it's best practice for bot tokens to be secure and not be stored in source code, which typically means using the ``dotenv`` module to load a `.env` file containing the bot's token.