### PR TITLE
Fix the 'user' and 'remove_all' parameters not working in Message#remove_reaction()

### DIFF
--- a/revolt/http.py
+++ b/revolt/http.py
@@ -404,9 +404,9 @@ class HttpClient:
         if user_id:
             parameters["user_id"] = user_id
 
-        parameters["remove_all"] = remove_all
+        parameters["remove_all"] = str(remove_all)
 
-        return self.request("DELETE", f"/channels/{channel_id}/messages/{message_id}/reactions/{emoji}")
+        return self.request("DELETE", f"/channels/{channel_id}/messages/{message_id}/reactions/{emoji}", params=parameters)
 
     def remove_all_reactions(self, channel_id: str, message_id: str) -> Request[None]:
         return self.request("DELETE", f"/channels/{channel_id}/messages/{message_id}/reactions")


### PR DESCRIPTION
The parameters dict containing `user_id` and `remove_all` are never passed to the request function, so attempting to remove a specific user's reactions or all reactions of a particular emoji will not work. This PR rectifies the issue by passing the parameters dict to the request function.

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
