### PR TITLE
Fix wrong type being passed to params dict for remove_reaction

### DIFF
--- a/revolt/http.py
+++ b/revolt/http.py
@@ -404,7 +404,7 @@ class HttpClient:
         if user_id:
             parameters["user_id"] = user_id
 
-        parameters["remove_all"] = remove_all
+        parameters["remove_all"] = "true" if remove_all else "false"
 
         return self.request("DELETE", f"/channels/{channel_id}/messages/{message_id}/reactions/{emoji}", params=parameters)
 


### PR DESCRIPTION
aiohttp's `request` method can only accept a dict with values of type str, float or int for the request's parameters. However, a boolean value is added to the parameters dictionary at this line:
https://github.com/revoltchat/revolt.py/blob/7ae2a566109fbf0a0e106462a7308798df59b2fe/revolt/http.py#L407

Because of this, aiottp throws the following error:
```
TypeError: Invalid variable type: value should be str, int or float, got False of type <class 'bool'>
```
This PR resolves the issue by converting the bool to either `"true"` or `"false"` before making the request.

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
