### PR TITLE
Raise proper exceptions when converters fail

### DIFF
--- a/revolt/ext/commands/converters.py
+++ b/revolt/ext/commands/converters.py
@@ -40,6 +40,8 @@ def category_converter(arg: str, context: Context[ClientT]) -> Category:
             return utils.get(context.server.categories, name=arg)
         except LookupError:
             raise CategoryConverterError(arg)
+    except LookupError:
+        raise CategoryConverterError(arg)
 
 def channel_converter(arg: str, context: Context[ClientT]) -> Channel:
     if not context.server_id:
@@ -55,6 +57,8 @@ def channel_converter(arg: str, context: Context[ClientT]) -> Channel:
             return utils.get(context.server.channels, name=arg)
         except LookupError:
             raise ChannelConverterError(arg)
+    except LookupError:
+        raise ChannelConverterError(arg)
 
 def user_converter(arg: str, context: Context[ClientT]) -> User:
     if (match := user_regex.match(arg)):
@@ -81,6 +85,8 @@ def user_converter(arg: str, context: Context[ClientT]) -> User:
 
         except LookupError:
             raise UserConverterError(arg)
+    except LookupError:
+        raise UserConverterError(arg)
 
 def member_converter(arg: str, context: Context[ClientT]) -> Member:
     if not context.server_id:
@@ -110,6 +116,8 @@ def member_converter(arg: str, context: Context[ClientT]) -> Member:
 
         except LookupError:
             raise MemberConverterError(arg)
+    except LookupError:
+        raise MemberConverterError(arg)
 
 def int_converter(arg: str, context: Context[ClientT]) -> int:
     return int(arg)


### PR DESCRIPTION
When the converters such as MemberConverter, ChannelConverter and UserConverter are unable to locate their respective item, they raise LookupErrors instead of the errors that are supposed to be raised when they fail—such as ChannelConverterError and MemberConverterError, for example. Since LookupError is raised for all of these converters when they can't find an item, it makes it difficult to distinguish between things like member lookup errors and channel lookup errors in `on_command_error()`.

This PR rectifies the issue by catching any `LookupError`s raised by the converters and instead raising the proper errors.

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
