### PR TITLE
fix: Server.create_role raising a KeyError

### DIFF
--- a/revolt/server.py
+++ b/revolt/server.py
@@ -147,7 +147,7 @@ class Server(Ulid):
         if banner := data.get("banner"):
             self.banner = Asset(banner, state)
         else:
-            self.banner  = None
+            self.banner = None
 
         self._members: dict[str, Member] = {}
         self._roles: dict[str, Role] = {role_id: Role(role, role_id, self, state) for role_id, role in data.get("roles", {}).items()}
@@ -426,8 +426,10 @@ class Server(Ulid):
             The role that was just created
         """
         payload = await self.state.http.create_role(self.id, name)
+        role_id = payload["id"]
+        data = payload["role"]
 
-        return Role(payload, name, self, self.state)
+        return Role(data, role_id, self, self.state)
 
     async def create_emoji(self, name: str, file: File, *, nsfw: bool = False) -> Emoji:
         """Creates an emoji

--- a/revolt/server.py
+++ b/revolt/server.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from .types import Server as ServerPayload
     from .types import SystemMessagesConfig
     from .types import Member as MemberPayload
+    from .types import Role as RolePayload
 
 __all__ = ("Server", "SystemMessages", "ServerBan")
 
@@ -426,8 +427,8 @@ class Server(Ulid):
             The role that was just created
         """
         payload = await self.state.http.create_role(self.id, name)
-        role_id = payload["id"]
-        data = payload["role"]
+        role_id: str = payload["id"]
+        data: RolePayload = payload["role"]
 
         return Role(data, role_id, self, self.state)
 


### PR DESCRIPTION
`Server.state.http.create_role` returns a payload in a format different from what `Role` expects. This pr extracts the needed information from `Server.state.http.create_role` to feed into `Role`

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
