### PR TITLE
Fix file uploads to Revolt backend

### DIFF
--- a/revolt/http.py
+++ b/revolt/http.py
@@ -94,7 +94,8 @@ class HttpClient:
         url = f"{self.api_info['features']['autumn']['url']}/{tag}"
 
         headers = {
-            "User-Agent": "Revolt.py (https://github.com/revoltchat/revolt.py)"
+            "User-Agent": "Revolt.py (https://github.com/revoltchat/revolt.py)",
+            self.auth_header: self.token
         }
 
         form = aiohttp.FormData()


### PR DESCRIPTION
This PR fixes file uploads failing due to requests missing the bot's authentication token, looks like Revolt recently started requiring this.

## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
